### PR TITLE
Make SSH command configurable for remote debug

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -836,9 +836,12 @@ Vimspector has in-built support for executing remote debuggers (such as
 where the development is done on one host and the runtime is
 some other host, account, container, etc.
 
-In order for it to work, you have to set up paswordless SSH between the local
-and remote machines/accounts. Then just tell Vimspector how to remotely launch
-and/or attach to the app.
+In order for it to work, it is preferred to have set up paswordless SSH between
+the local and remote machines/accounts. Then just tell Vimspector how to remotely
+launch and/or attach to the app. By default, 'ssh' command is being used.
+Optionally, the custom ssh command can be specified with cmd property which gives
+opportunity to use, e.g. sshpass, for non-interactive password passing to actual
+ssh client (see the [Python (debugpy) Example](#python-debugpy-example) below).
 
 This is presented as examples with commentary, as it's a fairly advanced/niche
 case. If you're not already familiar with remote debugging tools (such as
@@ -875,8 +878,9 @@ Vimspector then orchestrates the various tools to set you up.
                              // If omitted, runCommand(s) is run locally
           "account": "${account}", // User to connect as (optional)
 
-          // Optional.... Manual additional arguments for ssh
+          // Optional.... Manual ssh client and additional arguments
           // "ssh": {
+          //   "cmd": [ "sshpass", "-p", "pa$$w0rd", "ssh" ],
           //   "args": [ "-o", "StrictHostKeyChecking=no" ]
           // },
 
@@ -938,8 +942,9 @@ Vimspector then orchestrates the various tools to set you up.
           //   /* optional command to run after initialized */
           // ]
 
-          // Optional.... Manual additional arguments for ssh
+          // Optional.... Manual ssh client and additional arguments
           // "ssh": {
+          //   "cmd": [ "sshpass", "-p", "pa$$w0rd", "ssh" ],
           //   "args": [ "-o", "StrictHostKeyChecking=no" ]
           // },
         }

--- a/docs/schema/vimspector.schema.json
+++ b/docs/schema/vimspector.schema.json
@@ -107,11 +107,27 @@
                 },
                 "host": {
                   "type": "string",
-                  "description": "Name of the remote host to connect to (via passwordless SSH)."
+                  "description": "Name of the remote host to connect to (via passwordless SSH or with e.g. sshpass if ssh['cmd'] specified)."
                 },
                 "container": {
                   "type": "string",
                   "description": "Name or container id of the docker run container to connect to (via docker exec). Note the container must already be running (Vimspector will not start it) and it must have the port forwarded to the host if subsequently connecting via a port (for example <tt>docker run -p 8765:8765 -it simple_python</tt>)."
+                },
+                "ssh": {
+                  "type": "object",
+                  "description": "Optional to customize the ssh client and its arguments to execute for remote-launch or remote-attach.",
+                  "properties": {
+                    "cmd": {
+                      "type": "array",
+                      "items": { "type": "string" },
+                      "description": "Command to execute SSH client."
+                    },
+                    "args": {
+                      "type": "array",
+                      "items": { "type": "string" },
+                      "description": "SSH client command arguments."
+                    }
+                  }
                 }
               }
             },

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -1659,7 +1659,7 @@ class DebugSession( object ):
 
 
   def _GetSSHCommand( self, remote ):
-    ssh = [ 'ssh' ] + remote.get( 'ssh', {} ).get( 'args', [] )
+    ssh = remote.get( 'ssh', {} ).get( 'cmd', [ 'ssh' ]) + remote.get( 'ssh', {} ).get( 'args', [] )
     if 'account' in remote:
       ssh.append( remote[ 'account' ] + '@' + remote[ 'host' ] )
     else:

--- a/python3/vimspector/debug_session.py
+++ b/python3/vimspector/debug_session.py
@@ -1659,7 +1659,9 @@ class DebugSession( object ):
 
 
   def _GetSSHCommand( self, remote ):
-    ssh = remote.get( 'ssh', {} ).get( 'cmd', [ 'ssh' ]) + remote.get( 'ssh', {} ).get( 'args', [] )
+    ssh_config = remote.get( 'ssh', {} )
+    ssh = ssh_config.get( 'cmd', [ 'ssh' ] ) + ssh_config.get( 'args', [] )
+
     if 'account' in remote:
       ssh.append( remote[ 'account' ] + '@' + remote[ 'host' ] )
     else:


### PR DESCRIPTION
Allow to specify custom SSH command for remote debug, e.g. prepend ssh call with sshpass, etc.